### PR TITLE
Include link to SnapKit TeaVM demos

### DIFF
--- a/_data/examples.yml
+++ b/_data/examples.yml
@@ -32,3 +32,7 @@
   link: /live-examples/libgdx-demo-invaders/
   source_code: https://github.com/konsoletyper/teavm-libgdx
   thumbnail: invaders.png
+  
+- title: SnapKit Demos
+  link: http://reportmill.com/snaptea
+  thumbnail: SnapKitDemos.png


### PR DESCRIPTION
Updated to include link to SnapKit demos.

Github won't let me upload files to the img/examples folder, but a thumbnail is available here: http://reportmill.com/snaptea/SnapKitDemos.png