### PR TITLE
Adding an arrow to the image

### DIFF
--- a/_docs/tooling/idea.md
+++ b/_docs/tooling/idea.md
@@ -74,7 +74,7 @@ Simply press 'Refresh' button in the browser.
 How it works
 ------------
 
-Development server is a small HTTP server that runs embedded TeaVM compiler inside.
+Development server is a small HTTP server that runs an embedded TeaVM compiler inside.
 This compiler generates JavaScript in memory and serves it from the path you specified in settings.
 Additionally, the script may interact with the resources served by application server,
 which is on another address.


### PR DESCRIPTION
When I was following the tutorial, I missed that part at the bottom there.  What it gave me still worked, I just didn't even realize I was landing on http://localhost:9090/teavm_example_war_exploded/.  So once I got to the development server part, it wouldn't work until I added teavm_example_war_exploded/teavm in 'path to file'.  This was kind of confusing but I see now that I missed that step.  I think the arrow makes it a little more clear.  here is the updated image: https://i.imgur.com/QLzl2NW.png