### PR TITLE
Fix anchors for flavour/component-packages/html

### DIFF
--- a/_docs/flavour/component-packages/html.md
+++ b/_docs/flavour/component-packages/html.md
@@ -11,8 +11,8 @@ This package includes following components:
 * [enabled](#enabled)
 * [change](#change)
 * [checked-change](#checked-change)
-* [bidir-value](#change)
-* [bidir-checked](#change)
+* [bidir-value](#bidir-value)
+* [bidir-checked](#bidir-checked)
 * [link](#link)
 
 


### PR DESCRIPTION
bidir-value and bidir-checked linked to the wrong section