### PR TITLE
fix: Typo in example

### DIFF
--- a/_docs/flavour/component-packages/event.md
+++ b/_docs/flavour/component-packages/event.md
@@ -36,6 +36,6 @@ Example:
 ```html
 <div event:click="visible = not visible">
   <div>Click me to toggle!</div>
-  <div attr:style="'display: ' + (visible ? 'block' : 'hidden')">Lorem ipsum ...</div>
+  <div attr:style="'display: ' + (visible ? 'block' : 'none')">Lorem ipsum ...</div>
 </div>
 ```


### PR DESCRIPTION
Display has no attribute 'hidden'. Use 'none' instead. 

Thanks for your work on TeaVM. I really enjoy using it within my project at university this semester. Stay healthy : )