### PR TITLE
Fix gradle build command

### DIFF
--- a/src/docs/intro/getting-started.md
+++ b/src/docs/intro/getting-started.md
@@ -134,7 +134,7 @@ or if you need WebAssembly, HTML file like this:
 </html>
 ```
 
-now you can run build `gradle build` or, if you are using Gradle wrapper, `./gradlew build` or `gradlew.bat build`.
+now you can run build `gradle buildWasmGC` or, if you are using Gradle wrapper, `./gradlew buildWasmGC` or `gradlew.bat buildWasmGC`.
 Finally, take `.war` file from `build/libs` directory and deploy it to any compatible container or
 simply unzip and open `index.html`.
 


### PR DESCRIPTION
gradle `build` did not output anything, I think `buildWasmGC` is the right task to choose.

(Internal ref https://github.com/JabRef/jabref-koppor/pull/715)

Update: I am not sure how this relates to https://teavm.org/docs/tooling/gradle.html#Tasks